### PR TITLE
A very basic implementation of MiniML with tuples and records.

### DIFF
--- a/src/lang/AST.ml
+++ b/src/lang/AST.ml
@@ -1,0 +1,70 @@
+open Position
+
+type program = toplevel_definition list
+
+and toplevel_definition =
+  | ToplevelValue of value_definition
+  | TypeDefinition of type_introduction
+
+and type_introduction =
+  type_variable_identifier located list
+  * type_constructor_identifier located
+  * type_definition
+
+and type_definition =
+  | RecordType of (label located * ty located) list
+  | Abstract
+
+and value_definition =
+  | SimpleValue of
+        polymorphic_pattern located
+      * term located
+      * attribute list
+
+and attribute = Recursive
+
+and signature = declaration list
+
+and declaration =
+  | DeclareValue of identifier * type_scheme * attribute list
+  | DeclareType  of type_introduction
+
+and term =
+  | Var     of identifier
+  | Lit     of literal
+  | Let     of value_definition * term located
+  | Lam     of monomorphic_pattern located * term located
+  | App     of term located * term located
+  | Proj    of term located * label located
+  | Record  of (label located * term located) list
+  | Tuple   of term located list
+
+and 'kind pattern =
+  | PVar   of identifier * 'kind option
+  | PTuple of 'kind pattern located list
+
+and 'kind kind_descriptor =
+  | Monomorphic : ty kind_descriptor
+  | Polymorphic : type_scheme kind_descriptor
+
+and monomorphic_pattern = ty pattern
+
+and polymorphic_pattern = type_scheme pattern
+
+and literal =
+  | LInt of int
+
+and ty =
+  | TyVar of type_variable_identifier
+  | TyApp of type_constructor_identifier located * ty located list
+
+and type_scheme =
+  | TypeScheme of type_variable_identifier located list * ty located
+
+and identifier = Id of string
+
+and type_variable_identifier = TVId of string
+
+and type_constructor_identifier = TCId of string
+
+and label = LId of string

--- a/src/lang/Makefile
+++ b/src/lang/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all clean
+
+# Menhir can be told to produce a parser that explains what
+# it is doing.
+ifeq ($(DEBUGPARSING), yes)
+  MENHIROPT=-yaccflag --explain -yaccflag --trace
+else
+  MENHIROPT=-yaccflag --explain
+endif
+
+OCAMLBUILD=ocamlbuild -quiet -use-ocamlfind $(MENHIROPT)
+
+all:
+	$(OCAMLBUILD) lang.cma
+
+clean:
+	@ $(OCAMLBUILD) -clean
+	@ rm -f *~

--- a/src/lang/_tags
+++ b/src/lang/_tags
@@ -1,0 +1,2 @@
+<*> : use_menhir, package(pprint), package(unix), package(str), package(inferno)
+<*> : package(ocaml-compiler-libs)

--- a/src/lang/elaboration.ml
+++ b/src/lang/elaboration.ml
@@ -1,0 +1,550 @@
+open Position
+open AST
+open ProgramManipulation
+
+let type_error = Error.error "typing"
+
+type type_binding =
+  type_constructor_identifier * type_variable_identifier list * type_definition
+
+type environment =
+  Environment of type_binding list
+
+let bind_type_definition t ts td (Environment env) =
+  Environment ((t, ts, td) :: env)
+
+module S = struct
+
+  type 'a structure =
+    | TyApp of type_constructor_identifier located * 'a list
+
+  let rec map f (TyApp (t, ts)) = TyApp (t, List.map f ts)
+
+  let fold f (TyApp (_, ts)) accu = List.fold_right f ts accu
+
+  let iter f (TyApp (_, ts)) = List.iter f ts
+
+  exception Iter2
+
+  let rec iter2 f (TyApp (t, ts)) (TyApp (u, us)) =
+    let u = Position.value u and t = Position.value t in
+    if u = t then List.iter2 f ts us else raise Iter2
+
+end
+
+module O = struct
+
+  type tyvar =
+    int
+
+  type 'a structure =
+    'a S.structure
+
+  type ty =
+    AST.ty
+
+  let type_variable_identifier x =
+    let b = Buffer.create 13 in
+    let rec mangle x =
+      Buffer.add_char b (Char.chr (97 + x mod 26));
+      if x > 26 then mangle (x / 26)
+    in
+    mangle (Utilities.in_order x);
+    TVId (Buffer.contents b)
+
+  let variable x =
+    AST.TyVar (type_variable_identifier x)
+
+  let structure (S.TyApp (t, ts)) =
+    let pos = Position.position t in
+    let ts = List.map (Position.with_pos pos) ts in
+    AST.TyApp (t, ts)
+
+  let mu x t =
+    failwith "No recursive types"
+
+  type scheme =
+    tyvar list * ty
+
+end
+
+module Solver =
+  Inferno.SolverHi.Make(struct include String type tevar = t end)(S)(O)
+
+let located f x =
+  f (Position.position x) (Position.value x)
+
+let mk_tvar pos x =
+  with_pos pos (O.type_variable_identifier x)
+
+let mk_type_scheme pos ts ty =
+  TypeScheme (List.map (mk_tvar pos) ts, with_pos pos ty)
+
+let int_type =
+  S.TyApp (Position.unknown_pos (TCId "int"), [])
+
+let unit_type =
+  S.TyApp (Position.unknown_pos (TCId "unit"), [])
+
+let arrow t1 t2 =
+  S.TyApp (Position.unknown_pos (TCId "->"), [t1; t2])
+
+let pair t1 t2 =
+  S.TyApp (Position.unknown_pos (TCId "*"), [t1; t2])
+
+let fresh_variable_identifier =
+  let i = ref 0 in
+  fun () -> incr i; Printf.sprintf "_%d" !i
+
+open Solver
+
+let defn xs f =
+  let rec aux vs xs =
+    match xs with
+    | [] ->
+       f (List.rev vs) <$$> fun a -> ([], a)
+    | x :: xs ->
+       exist (fun v ->
+           def x v (aux (v :: vs) xs)
+         )
+       <$$> fun (ty, (tys, a)) -> (ty :: tys, a)
+  in
+  aux [] xs
+
+let rec conjs = function
+  | [] -> pure []
+  | [c] -> c <$$> fun x -> [x]
+  | c :: cs -> c ^& conjs cs <$$> fun (x, xs) -> x :: xs
+
+let existn xs f =
+  let rec aux vs = function
+    | [] ->
+       f (List.rev vs)
+    | x :: xs ->
+       exist (fun v -> aux ((x, v) :: vs) xs)
+       <$$> fun (ty, a) -> a
+  in
+  aux [] xs
+
+let rec is_productn v : _ list -> unit co = function
+  | [] ->
+     pure ()
+  | [x] ->
+     v -- x
+  | x :: xs ->
+     exist (fun v' -> v --- pair x v' ^& is_productn v' xs)
+     <$$> fun (_, ((), ())) -> ()
+
+let ctrue = pure ()
+
+(** Assume that the free variables of [ty] are existentially
+    quantified. *)
+let internalize_ty v ty =
+  let env = ref [] in
+  let rec aux v = function
+    | AST.TyVar x ->
+       begin try
+           v -- List.assoc x !env
+         with Not_found ->
+           env := (x, v) :: !env;
+           ctrue
+       end
+    | AST.TyApp (t, tys) ->
+       existn tys (fun xvs ->
+           let vs = snd (List.split xvs) in
+           List.fold_left (fun c (ty, v) ->
+               c ^^ aux v (Position.value ty)
+             ) (v --- S.TyApp (t, vs)) xvs
+         )
+  in
+  aux v ty
+
+let match_result (TypeScheme (_, sty)) ty =
+  let result_of_arrow =
+    exist (fun v1 ->
+        exist (fun v2 ->
+            exist (fun v3 ->
+                internalize_ty v3 ty
+                ^^ internalize_ty v2 sty.value
+                ^^ v2 --- arrow v1 v3)))
+    <$$> fun (ty, _) -> ProgramManipulation.unproduct ty
+  in
+  let exact_result =
+    exist (fun v ->
+        internalize_ty v ty
+        ^^ internalize_ty v sty.value)
+    <$$> fun _ -> []
+  in
+  try Some (snd (Solver.solve false (let0 result_of_arrow)))
+  with _ -> try Some (snd (Solver.solve false (let0 exact_result)))
+            with _ -> None
+
+exception UnboundLabel of label Position.located
+
+let lookup_projection (Environment env : environment) l =
+  try
+    let (t, ts, td) =
+      List.(find (fun (t, ts, td) ->
+                match td with
+                | AST.RecordType fds ->
+                   exists (fun (l', _) -> l'.value = l.value) fds
+                | _ -> false)
+              env)
+    in
+    let _, lty =
+      match td with
+      | AST.RecordType fds -> List.find (fun (l', _) -> l'.value = l.value) fds
+      | _ -> assert false (* By previous List.find. *)
+    in
+    let tys = List.map (fun x -> Position.with_pos l.position (TyVar x)) ts in
+    let rty = TyApp (Position.with_pos l.position t, tys) in
+    let ts = List.map (Position.with_pos l.position) ts in
+    (ts, rty, lty.value, td)
+  with Not_found ->
+    raise (UnboundLabel l)
+
+let type_constructor_arity (Environment env) t =
+  try
+    let (_, ts, td) = List.find (fun (t', _, _) -> t.value = t') env in
+    List.length ts
+  with Not_found ->
+    let TCId x = t.value in
+    type_error t.position (Printf.sprintf "Unbound type constructor `%s'." x)
+
+module ConstraintGeneration = struct
+
+let rec pattern_variables pos = function
+  | PVar (Id x, _) -> [x]
+  | PTuple ps -> List.(concat (map (located pattern_variables) ps))
+
+let rec program env (t : AST.program) : AST.program Solver.co =
+  match t with
+  | [] ->
+     pure []
+
+  | td :: tds ->
+     let env, constraint_ctx = toplevel_definition env td in
+     constraint_ctx (program env tds)
+
+and toplevel_definition (type a b) env = function
+  | ToplevelValue vd ->
+     let constraint_ctx = value_definition env vd in
+     let constraint_ctx = fun c ->
+       constraint_ctx c
+       <$$> fun (vd', u') -> (ToplevelValue vd') :: u'
+     in
+     (env, constraint_ctx)
+
+  | TypeDefinition td ->
+     let (env, ctx) = type_introduction env td in
+     let ctx = fun c ->
+       ctx c
+       <$$> fun (td, u) -> (TypeDefinition td) :: u in
+     (env, ctx)
+
+and signature env = function
+  | [] ->
+     (env, fun c -> c <$$> fun a -> ([], a))
+  | d :: ds ->
+     let env, ctx = declaration env d in
+     let env, ctx' = signature env ds in
+     let ctx = fun c ->
+       ctx (ctx' c)
+       <$$> fun (d, (ds, a)) -> (d :: ds, a)
+     in
+     (env, ctx)
+
+and declaration
+  : type a. _ -> _ -> _ * (a co -> (declaration * a) co)
+  = fun env -> function
+  | (DeclareValue (Id x, TypeScheme (ts, ty), _)) as d ->
+     let ctx = fun c ->
+       Solver.let1 x (fun v ->
+           internalize_ty v ty.value
+         ) c
+       <$$> fun (_, _, _, a) -> (d, a)
+     in
+     (env, ctx)
+
+  | DeclareType td ->
+     let (env, ctx) = type_introduction env td in
+     let ctx = fun c ->
+       ctx c <$$> fun (td, a) -> (DeclareType td, a)
+     in
+     (env, ctx)
+
+and type_introduction
+: type a. _ -> _ -> _ * (a co -> (type_introduction * a) co)
+= fun env (ts, t, td) ->
+  let env = type_definition env ts t td in
+  let constraint_ctx = fun c ->
+    c <$$> fun a -> ((ts, t, td), a)
+  in
+  (env, constraint_ctx)
+
+and type_definition env ts t td =
+  match td with
+  | Abstract ->
+     let ts' = List.map Position.value ts in
+     bind_type_definition t.value ts' td env
+  | RecordType fds ->
+     let ftvs =
+       TVSet.(List.fold_left (fun ftvs ty ->
+                  union ftvs (ftv ty.value))
+                empty (snd (List.split fds)))
+     in
+     let ts' = List.map Position.value ts in
+     if not TVSet.(subset ftvs (of_list ts')) then
+       type_error t.position "Undeclared type variable.";
+     List.iter (fun (l, _) -> try
+           ignore (lookup_projection env l);
+           type_error l.position "Label already used by another type."
+         with _ -> ()) fds;
+     let env = bind_type_definition t.value ts' (RecordType fds) env in
+     List.iter (located (well_formed_type env)) (snd (List.split fds));
+     env
+
+and well_formed_type env pos = function
+  | TyVar _ ->
+     ()
+  | TyApp (t, tys) ->
+     if type_constructor_arity env t <> List.length tys then
+       type_error t.position "Invalid application of type constructor.";
+     List.iter (located (well_formed_type env)) tys
+
+and value_definition
+: type a. _ -> value_definition -> a co -> (value_definition * a) co
+= fun env -> function
+  | SimpleValue (p, t, ats) -> fun c ->
+
+     let xs = located pattern_variables p in
+     Solver.letn xs (fun vs ->
+         let ctx c =
+           if List.mem Recursive ats then
+             defn xs (fun vs' ->
+                 conjs (List.map2 ( -- ) vs vs') ^^ c
+               ) <$$> fun (_, c) -> c
+           else
+             c
+         in
+         let xvs = List.combine xs vs in
+         ctx (
+             exist (fun v ->
+                 located (term env) t v
+                 ^& located (pattern env v xvs Polymorphic) p)
+           )
+     ) c
+
+     <$$> (fun (ss, ts, (_, (t', p')), a) ->
+         let pos = Position.position p in
+         let ss = List.map (fun (ts, ty) -> mk_type_scheme pos ts ty) ss in
+         let inferred = List.combine xs ss in
+         (SimpleValue (p' inferred, t', ats), a)
+       )
+
+and term env pos t ty =
+  match t with
+  | Lit (LInt x) ->
+
+     ty --- int_type
+
+     <$$> fun _ ->
+     with_pos pos t
+
+  | Var (Id x) ->
+
+     instance x ty
+
+     <$$> fun _ ->
+     with_pos pos t
+
+  | Lam (p, t) ->
+
+     let xs = located pattern_variables p in
+     exist (fun v1 ->
+         exist (fun v2 ->
+             defn xs (fun vs ->
+                 let xvs = List.combine xs vs in
+                 ty --- arrow v1 v2
+                 ^& located (pattern env v1 xvs Monomorphic) p
+                 ^& located (term env) t v2)))
+
+     <$$> fun (ty1, (ty2, (tys, ((), (p', t'))))) ->
+     let tys = List.(combine xs tys) in
+     with_pos pos (Lam (p' tys, t'))
+
+  | App (t, u) ->
+
+     exist (fun v1 ->
+         exist (fun v2 ->
+             v1 --- arrow v2 ty
+             ^& located (term env) t v1
+             ^& located (term env) u v2))
+
+    <$$> fun (ty1, (ty2, ((), (t', u')))) ->
+    with_pos pos (App (t', u'))
+
+  | Let (vd, t) ->
+     let constraint_context = value_definition env vd in
+
+     constraint_context (located (term env) t ty)
+
+     <$$> fun (vd, t) ->
+     with_pos pos (Let (vd, t))
+
+  | Tuple [t] ->
+     located (term env) t ty
+
+  | Tuple (t :: ts) ->
+
+     let t' = match ts with
+       | [] -> assert false
+       | [t] -> t
+       | ts -> with_pos pos (Tuple ts)
+     in
+
+     exist (fun v1 ->
+         exist (fun v2 ->
+             ty --- pair v1 v2
+             ^& located (term env) t v1
+             ^& located (term env) t' v2))
+
+     <$$> fun (_, (_, ((), (t, t')))) ->
+     with_pos pos begin match Position.value t' with
+     | Tuple ts -> Tuple (t :: ts)
+     | _ -> Tuple [t; t']
+     end
+
+  | Proj (t, l) ->
+     let (_, rty, lty, _) = lookup_projection env l in
+     let rty = Position.with_pos t.position rty in
+     let lty = Position.with_pos l.position lty in
+     exist_ (fun vr ->
+         exist_ (fun vv ->
+             vv --- arrow vr ty
+             ^^ internalize_ty vv (ProgramManipulation.arrow pos rty lty)
+             ^^ located (term env) t vr))
+     <$$> (fun t' -> with_pos pos (Proj (t', l)))
+
+  | Record (((l, _) :: _) as fs) ->
+     let (_, rty, _, td) = lookup_projection env l in
+     begin match td with
+     | RecordType fds ->
+        let compare_label (l1, _) (l2, _) = compare l1.value l2.value in
+        let fds = List.sort compare_label fds
+        and fs = List.sort compare_label fs in
+        exist_ (fun va ->
+            exist_ (fun vp ->
+                existn fds (fun fdvs ->
+                    let vs = snd (List.split fdvs) in
+                    let ftys = snd (List.split fds) in
+                    let rty = with_pos pos rty in
+                    let all = ProgramManipulation.(
+                        arrow pos (productn pos ftys) rty
+                    ) in
+                    internalize_ty va all
+                    ^^ va --- arrow vp ty
+                    ^^ is_productn vp vs
+                    ^^ let rec fields fs fds =
+                         match fs, fds with
+                         | [], [] ->
+                            pure []
+                         | ({ value = LId x } as l, e) :: fs, (l', _) :: fds ->
+                            if l.value <> l'.value then
+                              type_error l.position (
+                                  Printf.sprintf "`%s' is an invalid label." x
+                                );
+                            let (_, v) =
+                              try
+                                List.find (fun ((l'', _), _) ->
+                                    l''.value = l.value
+                                  ) fdvs
+                              with Not_found -> assert false (* By existn. *)
+                            in
+                            located (term env) e v ^& fields fs fds
+                            <$$> fun (t, ts) -> (l, t) :: ts
+                         | ({ value = LId x } as l, e) :: _, [] ->
+                            type_error l.position (
+                                Printf.sprintf "`%s' is an invalid label." x
+                              )
+                         | [], (({ value = LId x } as l), _) :: _ ->
+                            type_error l.position (
+                                Printf.sprintf "A value for `%s' is missing." x
+                              )
+                       in
+                       fields fs fds)))
+        <$$> fun fs -> with_pos pos (Record fs)
+     | _ ->
+        assert false (* By lookup_projection. *)
+     end
+
+  | Tuple [] ->
+     (ty --- unit_type) <$$> fun () -> with_pos pos (Tuple [])
+
+  | Record [] ->
+     assert false (* By syntax. *)
+
+and pattern
+: type a kind.
+  _ -> _ -> _ -> kind kind_descriptor
+  -> _ -> kind pattern ->
+  ((string * a) list -> a pattern located) co
+= fun env v xvs kd pos -> function
+  | PVar (Id x, a) ->
+     let v' = try List.assoc x xvs with _ -> assert false in
+     (match a with
+      | None -> ctrue
+      | Some a ->
+         match kd with
+         | Monomorphic -> (* a is a ty. *)
+            internalize_ty v' a
+         | Polymorphic -> (* a is a type scheme. *)
+            let TypeScheme (_, ty) = a in
+            internalize_ty v' ty.value)
+     ^^ v -- v'
+     <$$> fun () ->
+     fun (inferred_schemes : (string * a) list) ->
+     let s =
+       try List.assoc x inferred_schemes with _ -> assert false
+     in
+     with_pos pos (PVar (Id x, Some s))
+
+   | PTuple ps ->
+      existn ps (fun xps ->
+          (is_productn v (snd (List.split xps)))
+          ^& conjs (List.map (fun (p, v) ->
+                        located (pattern env v xvs kd) p) xps))
+      <$$> fun (_, ps) inferred ->
+      let ps = List.map (fun p -> p inferred) ps in
+      with_pos pos (PTuple ps)
+
+end
+
+let initial_env : environment = AST.(
+
+  Environment [
+
+      (let a = TVId "'a" and b = TVId "'b" in (TCId "->", [a; b], Abstract));
+
+      (TCId "int", [], Abstract);
+
+      (TCId "unit", [], Abstract);
+
+    ]
+)
+
+let process basename ast =
+  try
+    let program_constraint = ConstraintGeneration.program initial_env ast in
+    let global_constraint = let0 program_constraint in
+    snd (Solver.solve false global_constraint)
+  with
+  | Unify (ty1, ty2) ->
+     type_error Position.dummy (
+         Printf.sprintf
+           "Incompatible types: %s <> %s\n"
+           (Printer.string_of Printer.ty ty1)
+           (Printer.string_of Printer.ty ty2))
+
+  | UnboundLabel ({ value = LId l; position }) ->
+     type_error position (Printf.sprintf "Unbound label `%s'." l)

--- a/src/lang/error.ml
+++ b/src/lang/error.ml
@@ -1,0 +1,29 @@
+let exit_flag = ref true
+
+let exit_on_error () = exit_flag := true
+
+let resume_on_error () = exit_flag := false
+
+exception Error of Position.t list * string
+
+let print_error positions msg =
+  Printf.sprintf "%s%s\n"
+    (String.concat "\n"
+       (List.map (fun p -> Position.string_of_pos p ^": ") positions))
+    msg
+
+let error_alert positions msg =
+  if !exit_flag then (
+    output_string stderr (print_error positions msg);
+    exit 1
+  )
+  else raise (Error (positions, msg))
+
+let global_error kind msg =
+  error_alert [] (Printf.sprintf "Global Error (%s)\n  %s"  kind msg)
+
+let errorN kind poss msg =
+  error_alert poss (Printf.sprintf "Error (%s)\n  %s" kind msg)
+
+let error kind pos = errorN kind [pos]
+let error2 kind pos1 pos2 = errorN kind [pos1; pos2]

--- a/src/lang/error.mli
+++ b/src/lang/error.mli
@@ -1,0 +1,28 @@
+(** This module provides a uniform way of reporting (located) error message. *)
+
+(** [exit_on_error ()] forces the program to stop if an error is encountered.
+    (This is the default behavior.) *)
+val exit_on_error: unit -> unit
+
+(** [resume_on_error ()] makes the program throw the exception {!Error}
+    if an error is encountered. *)
+val resume_on_error: unit -> unit
+
+exception Error of Position.t list * string
+
+(** [print_error positions msg] formats an error message. *)
+val print_error : Position.t list -> string -> string
+
+(** [error k p msg] prints [msg] with [k] as a message prefix and stops
+    the program. *)
+val error : string -> Position.t -> string -> 'a
+
+(** [error2 k p1 p2 msg] prints two positions instead of one. *)
+val error2 : string -> Position.t -> Position.t -> string -> 'a
+
+(** [errorN k ps msg] prints several positions. *)
+val errorN : string -> Position.t list -> string -> 'a
+
+(** [global_error k msg] prints [msg] with [k] as a message prefix and stops
+    the program. *)
+val global_error : string -> string -> 'a

--- a/src/lang/extStd.ml
+++ b/src/lang/extStd.ml
@@ -1,0 +1,67 @@
+module List = struct
+  let push r x = r := x :: !r
+
+  let last l = List.(hd (rev l))
+
+  let fold_map f init xs =
+    let rec aux accu ys = function
+      | [] ->
+         (accu, List.rev ys)
+      | x :: xs ->
+         let accu, y = f accu x in
+         aux accu (y :: ys) xs
+    in
+    aux init [] xs
+
+  module Monad : sig
+
+    type 'a nondeterministic
+    type 'a t = 'a nondeterministic
+
+    val return : 'a -> 'a t
+    val fail : 'a t
+    val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+    val pick : 'a list -> 'a t
+    val run : 'a t -> 'a list
+
+    val map : ('a -> 'b t) -> 'a list -> 'b list t
+
+  end = struct
+
+    type 'a nondeterministic = 'a list
+    type 'a t = 'a nondeterministic
+
+    let return x = [x]
+    let fail = []
+
+    let ( >>= ) x f =
+      List.(flatten (map f x))
+
+    let pick x = x
+
+    let run x = x
+
+    let map f xs =
+      let rec aux = function
+        | [] ->
+           return []
+        | x :: xs ->
+           f x >>= fun y ->
+           aux xs >>= fun ys ->
+           return (y :: ys)
+      in
+      aux xs
+
+  end
+
+end
+
+module Unix = struct
+
+  let line_of_command cmd =
+    let cin = Unix.open_process_in cmd in
+    let line = input_line cin in
+    let status = Unix.close_process_in cin in
+    (status, line)
+
+end

--- a/src/lang/lang.ml
+++ b/src/lang/lang.ml
@@ -1,0 +1,15 @@
+open Options
+open Printer
+
+let configuration =
+  Error.resume_on_error ()
+
+let parse content =
+  let lexbuf = Lexing.from_string content in
+  Parser.program Lexer.token lexbuf
+
+let elaborate iast =
+  Elaboration.process "buffer" iast
+
+let print ast =
+  Printer.(string_of (program false) ast)

--- a/src/lang/lang.mli
+++ b/src/lang/lang.mli
@@ -1,0 +1,13 @@
+(** API to the VIT language subsystem. *)
+
+val parse : string -> AST.program
+(** [parse content] turns a string into an abstract syntax tree if it
+    is syntactically correct. *)
+
+val print : AST.program -> string
+(** [print p] represents the abstract syntax tree [p] is a human readable
+    form. *)
+
+val elaborate : AST.program -> AST.program
+(** [elaborate p] translate the implicitly typed program [p] into an
+    explicitly typed program if [p] is well-typed. *)

--- a/src/lang/lang.mllib
+++ b/src/lang/lang.mllib
@@ -1,0 +1,12 @@
+ExtStd
+Error
+Options
+Position
+Utilities
+AST
+ProgramManipulation
+Lexer
+Parser
+Printer
+Elaboration
+Lang

--- a/src/lang/lang.top
+++ b/src/lang/lang.top
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+make
+utop -I _build/ -require pprint -require inferno _build/lang.cma

--- a/src/lang/lexer.mll
+++ b/src/lang/lexer.mll
@@ -1,0 +1,114 @@
+{ (* -*- tuareg -*- *)
+  open Parser
+
+  let lexical_error lexbuf msg =
+    Error.error "Lexing" (Position.cpos lexbuf) msg
+}
+
+let newline = ('\010' | '\013' | "\013\010")
+
+let blank   = [' ' '\009' '\012']
+
+let digit = ['0'-'9']
+
+let identifier = ['a'-'z''0'-'9''_']+
+
+let uidentifier = ['A'-'Z']['a'-'z''0'-'9''_']*
+
+let number = digit+
+
+rule token = parse
+| blank {
+  token lexbuf
+}
+| newline {
+  Lexing.new_line lexbuf;
+  token lexbuf
+}
+| "(*" {
+  comment 0 lexbuf
+}
+| ":" {
+  COLON
+}
+| ";" {
+  SEMICOLON
+}
+| "," {
+  COMMA
+}
+| "=" {
+  EQUAL
+}
+| "type" {
+  TYPE
+}
+| "let" {
+  LET
+}
+| "rec" {
+  REC
+}
+| "in" {
+  IN
+}
+| "fun" {
+  FUN
+}
+| "->" {
+  RARROW
+}
+| "." {
+  DOT
+}
+| "'" (identifier as s) {
+  TVID s
+}
+| "{"
+{
+  LBRACE
+}
+| "}"
+{
+  RBRACE
+}
+| "("
+{
+  LPAREN
+}
+| ")"
+{
+  RPAREN
+}
+| number as i {
+  INT (int_of_string i)
+}
+| identifier as s {
+  ID s
+}
+| eof {
+  EOF
+}
+| _ as c {
+  lexical_error lexbuf (
+    Printf.sprintf "Unexpected character `%c'." c
+  )
+}
+
+and comment level = parse
+| "(*"
+{
+  comment (level + 1) lexbuf
+}
+| "*)"
+{
+  if level = 0 then token lexbuf else comment (level - 1) lexbuf
+}
+| eof
+{
+  lexical_error lexbuf "Unclosed comment."
+}
+| _
+{
+  comment level lexbuf
+}

--- a/src/lang/options.ml
+++ b/src/lang/options.ml
@@ -1,0 +1,2 @@
+let trace = ref false
+let init = ref false

--- a/src/lang/parser.mly
+++ b/src/lang/parser.mly
@@ -1,0 +1,254 @@
+%{ (* -*- tuareg -*- *)
+
+open AST
+
+let parse_error pos msg =
+  Error.error "Parsing" pos msg
+
+let rec lam pos ps t =
+  match ps with
+  | [] -> t
+  | p :: ps -> Lam (p, Position.with_pos pos (lam pos ps t))
+
+%}
+
+(** Keywords. *)
+%token TYPE LET REC IN FUN
+
+(** Punctuation. *)
+%token EQUAL RARROW COLON COMMA SEMICOLON DOT
+
+(** Structural symbols. *)
+%token LBRACE RBRACE LPAREN RPAREN EOF
+
+(** Identifiers. *)
+%token<string> ID TVID
+
+(** Literals. *)
+%token<int> INT
+
+%start<AST.program> program
+
+%nonassoc IN COLON
+%right RARROW
+%left ID INT
+%left LPAREN
+%nonassoc RPAREN
+
+%%
+
+program: ds=toplevel_definition* EOF
+{
+  ds
+}
+| e=located(error)
+{
+  parse_error (Position.position e) "Syntax error."
+}
+
+toplevel_definition:
+vd=value_definition
+{
+  ToplevelValue vd
+}
+| t=type_introduction
+{
+  TypeDefinition t
+}
+
+type_introduction:
+TYPE
+  ts=type_parameters
+  tycon=located(type_constructor_identifier)
+  td=type_definition
+{
+  (ts, tycon, td)
+}
+
+type_parameters:
+t=located(type_variable_identifier)
+{
+  [t]
+}
+| LPAREN
+  ts=separated_nonempty_list(COMMA, located(type_variable_identifier))
+  RPAREN
+{
+  ts
+}
+| /* empty */
+{
+  []
+}
+
+type_definition:
+EQUAL LBRACE fs=separated_nonempty_list(SEMICOLON, field_declaration) RBRACE
+{
+  RecordType fs
+}
+
+field_declaration:
+l=located(label) COLON t=located(typ)
+{
+  (l, t)
+}
+
+value_definition:
+LET r=REC? x=located(pattern(type_scheme)) 
+EQUAL t=located(term)
+{
+  let ats = if r = None then [] else [Recursive] in
+  SimpleValue (x, t, ats)
+}
+| LET r=REC? x=located(identifier) p=arguments EQUAL t=term
+{
+  let pos = Position.lex_join $startpos(p) $endpos(t) in
+  let f = Position.map (fun x -> PVar (x, None)) x in
+  let ats = if r = None then [] else [Recursive] in
+  SimpleValue (f, Position.with_pos pos (lam pos p t), ats)
+}
+
+arguments: a=argument
+{
+  [a]
+}
+| a=argument p=arguments
+{
+  a :: p
+}
+
+term:
+vd=value_definition IN t=located(term)
+{
+  Let (vd, t)
+}
+| t=located(term) u=located(simple_term)
+{
+  App (t, u)
+}
+| FUN a=argument+ RARROW t=term
+{
+  let pos = Position.lex_join $startpos $endpos(t) in
+  lam pos a t
+}
+| LBRACE
+  fs=separated_nonempty_list(SEMICOLON, field_definition)
+  RBRACE
+{
+  Record fs
+}
+| s=simple_term
+{
+  s
+}
+
+simple_term:
+x=identifier
+{
+  Var x
+}
+| x=INT
+{
+  Lit (LInt x)
+}
+| s=located(simple_term) DOT l=located(label)
+{
+  Proj (s, l)
+}
+| LPAREN ts=separated_nonempty_list(COMMA, located(term)) RPAREN
+{
+  match ts with
+  | [] -> assert false (* By grammar. *)
+  | [t] -> Position.value t
+  | ts -> Tuple ts
+}
+
+field_definition: l=located(label) EQUAL t=located(term)
+{
+  (l, t)
+}
+
+typ:
+alpha=type_variable_identifier
+{
+  TyVar alpha
+}
+| ity=located(typ) RARROW oty=located(typ)
+{
+  let pos = Position.lex_join $startpos $endpos in
+  ProgramManipulation.arrow pos ity oty
+}
+| tycon=located(type_constructor_identifier)
+{
+  TyApp (tycon, [])
+}
+| LPAREN arg=located(typ) RPAREN
+  tycon=located(type_constructor_identifier)
+{
+  TyApp (tycon, [arg])
+}
+| LPAREN
+  arg=located(typ) COMMA args=separated_nonempty_list(COMMA, located(typ)) 
+  RPAREN
+  tycon=located(type_constructor_identifier)
+{
+  TyApp (tycon, arg :: args)
+}
+| LPAREN t=typ RPAREN
+{
+  t
+}
+
+type_scheme:
+ty=located(typ)
+{
+  TypeScheme ([], ty)
+}
+| ts=nonempty_list(located (type_variable_identifier)) DOT ty=located(typ)
+{
+  TypeScheme (ts, ty)
+}
+
+argument:
+x=located(pattern(typ))
+{
+  x
+}
+
+pattern(kind):
+x=identifier
+{
+  PVar (x, None)
+}
+| x=identifier COLON a=kind
+{
+  PVar (x, Some a)
+}
+| LPAREN ps=separated_nonempty_list(COMMA, located(pattern(kind))) RPAREN
+{
+  PTuple ps
+}
+
+identifier: x=ID
+{
+  Id x
+}
+
+label: x=ID
+{
+  LId x
+}
+
+type_constructor_identifier: x=ID
+{
+  TCId x
+}
+
+type_variable_identifier: x=TVID
+{
+  TVId x
+}
+
+%inline located(X): x=X {
+  Position.with_poss $startpos $endpos x
+}

--- a/src/lang/position.ml
+++ b/src/lang/position.ml
@@ -1,0 +1,137 @@
+open Lexing
+
+type t =
+    {
+      start_p : Lexing.position;
+      end_p   : Lexing.position
+    }
+
+type position = t
+
+type 'a located =
+    {
+      value    : 'a;
+      position : t;
+    }
+
+let value { value = v } =
+  v
+
+let position { position = p } =
+  p
+
+let destruct p =
+  (p.value, p.position)
+
+let located f x =
+  f (value x)
+
+let with_pos p v =
+  {
+    value     = v;
+    position  = p;
+  }
+
+let with_poss p1 p2 v =
+  with_pos { start_p = p1; end_p = p2 } v
+
+let map f v =
+  {
+    value     = f v.value;
+    position  = v.position;
+  }
+
+let iter f { value = v } =
+  f v
+
+let mapd f v =
+  let w1, w2 = f v.value in
+  let pos = v.position in
+    ({ value = w1; position = pos }, { value = w2; position = pos })
+
+let dummy =
+  {
+    start_p = Lexing.dummy_pos;
+    end_p   = Lexing.dummy_pos
+  }
+
+let unknown_pos v =
+  {
+    value     = v;
+    position  = dummy
+  }
+
+let start_of_position p = p.start_p
+
+let end_of_position p = p.end_p
+
+let filename_of_position p =
+  p.start_p.Lexing.pos_fname
+
+let line p =
+  p.pos_lnum
+
+let column p =
+  p.pos_cnum - p.pos_bol
+
+let characters p1 p2 =
+  (column p1, p2.pos_cnum - p1.pos_bol) (* intentionally [p1.pos_bol] *)
+
+let join x1 x2 =
+  {
+    start_p = if x1 = dummy then x2.start_p else x1.start_p;
+    end_p   = if x2 = dummy then x1.end_p else x2.end_p
+  }
+
+let lex_join x1 x2 =
+  {
+    start_p = x1;
+    end_p   = x2
+  }
+
+let join_located l1 l2 f =
+  {
+    value    = f l1.value l2.value;
+    position = join l1.position l2.position;
+  }
+
+let string_of_lex_pos p =
+  let c = p.pos_cnum - p.pos_bol in
+  (string_of_int p.pos_lnum)^":"^(string_of_int c)
+
+let string_of_pos p =
+  let filename = filename_of_position p in
+  let l = line p.start_p in
+  let c1, c2 = characters p.start_p p.end_p in
+    if filename = "" then
+      Printf.sprintf "Line %d, characters %d-%d" l c1 c2
+    else 
+      Printf.sprintf "File \"%s\", line %d, characters %d-%d" filename l c1 c2
+
+let pos_or_undef = function
+  | None -> dummy
+  | Some x -> x
+
+let cpos lexbuf =
+  {
+    start_p = Lexing.lexeme_start_p lexbuf;
+    end_p   = Lexing.lexeme_end_p   lexbuf;
+  }
+
+let with_cpos lexbuf v =
+  with_pos (cpos lexbuf) v
+
+let string_of_cpos lexbuf =
+  string_of_pos (cpos lexbuf)
+
+let joinf f t1 t2 =
+  join (f t1) (f t2)
+
+let ljoinf f =
+  List.fold_left (fun p t -> join p (f t)) dummy
+
+let join_located_list ls f =
+  {
+    value     = f (List.map (fun l -> l.value) ls);
+    position  = ljoinf (fun x -> x.position) ls
+  }

--- a/src/lang/position.mli
+++ b/src/lang/position.mli
@@ -1,0 +1,109 @@
+(** Extension of standard library's positions. *)
+
+(** {2 Extended lexing positions} *)
+
+(** Abstract type for pairs of positions in the lexing stream. *)
+type t
+type position = t
+
+(** Decoration of a value with a position. *)
+type 'a located =
+    {
+      value    : 'a;
+      position : t;
+    }
+
+(** [value dv] returns the raw value that underlies the
+    decorated value [dv]. *)
+val value: 'a located -> 'a
+
+(** [position dv] returns the position that decorates the
+    decorated value [dv]. *)
+val position: 'a located -> t
+
+(** [destruct dv] returns the couple of position and value
+    of a decorated value [dv]. *)
+val destruct: 'a located -> 'a * t
+
+(** [located f x] applies [f] to the value of [x]. *)
+val located : ('a -> 'b) -> 'a located -> 'b
+
+(** [with_pos p v] decorates [v] with a position [p]. *)
+val with_pos : t -> 'a -> 'a located
+
+(** [with_cpos p v] decorates [v] with a lexical position [p]. *)
+val with_cpos: Lexing.lexbuf -> 'a -> 'a located
+
+(** [with_poss start stop v] decorates [v] with a position [(start, stop)]. *)
+val with_poss : Lexing.position -> Lexing.position -> 'a -> 'a located
+
+(** [unknown_pos x] decorates [v] with an unknown position. *)
+val unknown_pos : 'a -> 'a located
+
+(** This value is used when an object does not come from a particular
+    input location. *)
+val dummy: t
+
+(** [map f v] extends the decoration from [v] to [f v]. *)
+val map: ('a -> 'b) -> 'a located -> 'b located
+
+(** [iter f dv] applies [f] to the value inside [dv]. *)
+val iter: ('a -> unit) -> 'a located -> unit
+
+(** [mapd f v] extends the decoration from [v] to both members of the pair
+    [f v]. *)
+val mapd: ('a -> 'b1 * 'b2) -> 'a located -> 'b1 located * 'b2 located
+
+(** {2 Accessors} *)
+
+(** [column p] returns the number of characters from the
+    beginning of the line of the Lexing.position [p]. *)
+val column : Lexing.position -> int
+
+(** [column p] returns the line number of to the Lexing.position [p]. *)
+val line : Lexing.position -> int
+
+(** [characters p1 p2] returns the character interval
+    between [p1] and [p2] assuming they are located in the same
+    line. *)
+val characters : Lexing.position -> Lexing.position -> int * int
+
+(** [start_of_position p] returns the beginning of a position [p]. *)
+val start_of_position: t -> Lexing.position
+
+(** [end_of_position p] returns the end of a position [p]. *)
+val end_of_position: t -> Lexing.position
+
+(** [filename_of_position p] returns the filename of a position [p]. *)
+val filename_of_position: t -> string
+
+(** {2 Position handling} *)
+
+(** [join p1 p2] returns a position that starts where [p1]
+    starts and stops where [p2] stops. *)
+val join : t -> t -> t
+
+(** [lex_join l1 l2] returns a position that starts at [l1] and stops
+    at [l2]. *)
+val lex_join : Lexing.position -> Lexing.position -> t
+
+(** [string_of_lex_pos p] returns a string representation for
+    the lexing position [p]. *)
+val string_of_lex_pos : Lexing.position -> string
+
+(** [string_of_pos p] returns the standard (Emacs-like) representation
+    of the position [p]. *)
+val string_of_pos : t -> string
+
+(** [pos_or_undef po] is the identity function except if po = None,
+    in that case, it returns [undefined_position]. *)
+val pos_or_undef : t option -> t
+
+(** {2 Interaction with the lexer runtime} *)
+
+(** [cpos lexbuf] returns the current position of the lexer. *)
+val cpos : Lexing.lexbuf -> t
+
+(** [string_of_cpos p] returns a string representation of
+    the lexer's current position. *)
+val string_of_cpos : Lexing.lexbuf -> string

--- a/src/lang/printer.ml
+++ b/src/lang/printer.ml
@@ -1,0 +1,222 @@
+open PPrint
+open PPrintEngine
+open PPrintCombinators
+open AST
+
+let printer_error pos msg =
+  Error.error "printing" pos msg
+
+let ( ++ ) a b =
+  a ^^ break 1 ^^ b
+
+let located f x =
+  f (Position.value x)
+
+let located' f x =
+  f (Position.position x) (Position.value x)
+
+let optionally f x =
+  match x with
+  | None -> empty
+  | Some y -> f y
+
+let kwd = string
+
+let sym = string
+
+let comma_separated f xs = separate_map (sym "," ^^ break 1) f xs
+
+let semi_separated f xs = separate_map (sym ";" ^^ break 1) f xs
+
+let break_separated f xs = separate_map (break 1) f xs
+
+let rec program ocaml ds =
+  separate_map (hardline ^^ hardline) (toplevel_definition ocaml) ds
+
+and toplevel_definition ocaml = function
+  | ToplevelValue vd ->
+     group (value_definition ocaml vd)
+  | TypeDefinition td ->
+     type_introduction td
+
+and type_introduction (ts, t, td) =
+  group (
+      kwd "type"
+      ^^ group (group (type_parameters ts)
+                ++ located type_constructor_identifier t)
+      ++ type_definition td
+    )
+
+and signature ocaml s =
+  break_separated (declaration ocaml) s
+
+and declaration ocaml = function
+  | DeclareValue (x, s, ats) ->
+     group (kwd "val"
+            ^^ attributes ocaml ats
+            ++ identifier x ++ sym ":" ++ type_scheme s)
+
+  | DeclareType td ->
+     type_introduction td
+
+and type_definition = function
+  | RecordType fs ->
+     sym "=" ++ braces (semi_separated field_declaration fs)
+  | Abstract ->
+     empty
+
+and type_parameters = function
+  | [] ->
+     empty
+  | [t] ->
+     break 1 ^^ located type_variable_identifier t
+  | ts ->
+     break 1 ^^ parens (comma_separated (located type_variable_identifier) ts)
+
+and field_declaration (f, t) =
+  group (located label f ^^ sym ":" ++ located ty t)
+
+and value_definition ocaml = function
+  | SimpleValue (p, t, ats) ->
+     nest 2 (
+       group (
+         group (kwd "let "
+                ^^ (attributes ocaml ats)
+                ^^ located (pattern false type_scheme) p)
+         ++ sym "=")
+       ++ located' (term ocaml) t
+     )
+
+and attributes ocaml = function
+  | [] ->
+     empty
+  | ats ->
+     group (break_separated (attribute ocaml) ats ^^ break 1)
+
+and attribute ocaml = function
+  | Recursive ->
+     kwd "rec"
+
+and forbidden_in ocaml pos =
+  if ocaml then printer_error pos "This construction is forbidden in OCaml."
+
+and term ocaml pos = function
+  | Var x ->
+     identifier x
+  | Lit l ->
+     literal l
+  | Let (vd, t) ->
+     group (value_definition ocaml vd ++ kwd "in")
+     ++ group (located' (term ocaml) t)
+  | Lam (p, t) ->
+     nest 2 (
+         group (group (kwd "fun" ++ argument ocaml p) ++ sym "->")
+         ++ group (located' (term ocaml) t)
+     )
+  | App (t, u) ->
+     group (located (may_paren_term ocaml pos `LeftOfApp) t
+            ++ located (may_paren_term ocaml pos `RightOfApp) u)
+  | Proj (t, l) ->
+     located (may_paren_term ocaml pos `UnderProj) t
+     ^^ sym "." ^^ located label l
+  | Record fs ->
+     braces (semi_separated (field ocaml pos) fs)
+  | Tuple  ts  ->
+     group (PPrintOCaml.tuple (
+         List.map (located (may_paren_term ocaml pos `UnderTuple)) ts
+       ))
+
+and may_paren_term ocaml pos context t =
+  if match context, t with
+     | (`LeftOfApp | `UnderTuple),
+       (Lam _ | Let _)
+       -> true
+     | (`RightOfApp | `UnderNil | `UnderMove | `UnderDiff | `UnderBang
+        | `UnderDerive | `UnderCached | `UnderProj | `Field),
+       t ->
+        (match t with Lit _ | Var _ | Tuple _ -> false | _ -> true)
+     | _ -> false
+  then
+    group (parens (term ocaml pos t))
+  else
+    term ocaml pos t
+
+and argument ocaml p =
+  located (pattern ocaml ty) p
+
+and field ocaml pos (l, t) =
+  group (group (located label l ++ sym "=")
+         ++ group (located (may_paren_term ocaml pos `Field) t))
+
+and pattern
+: type a. _ -> (a -> document) -> a pattern -> document
+= fun ocaml annotation -> function
+  | PVar (x, None) ->
+     identifier x
+  | PVar (x, Some a) ->
+     if ocaml then
+       identifier x
+     else
+       group (identifier x ++ sym ": " ^^ annotation a)
+  | PTuple ps ->
+     group (parens (comma_separated (located (pattern ocaml annotation)) ps))
+
+and literal = function
+  | LInt x ->
+     string (string_of_int x)
+
+and ty = function
+  | TyVar x ->
+     type_variable_identifier x
+  | TyApp (t, []) ->
+     group (located type_constructor_identifier t)
+  | TyApp ({ Position.value = TCId "->" }, [t1; t2]) ->
+     group (group (may_paren_ty t1 ++ sym "->") ++ located ty t2)
+  | TyApp ({ Position.value = TCId "*" }, [t1; t2]) ->
+     group (group (may_paren_ty t1 ++ sym "*" ++ may_paren_ty t2))
+  | TyApp (t, ts) ->
+     group (PPrintOCaml.tuple (List.map (located ty) ts)
+            ++ located type_constructor_identifier t)
+
+and may_paren_ty t =
+  match Position.value t with
+  | TyApp ({ Position.value = TCId "->" }, [t1; t2]) ->
+     parens (located ty t)
+  | _ ->
+     located ty t
+
+and type_scheme_annotation s =
+  break 1 ^^ group (sym ":" ++ type_scheme s)
+
+and type_scheme = function
+  | TypeScheme ([], t) ->
+     located ty t
+  | TypeScheme (ts, t) ->
+     group (
+         separate_map (blank 1) (located type_variable_identifier) ts
+         ^^ sym "." ++ located ty t
+       )
+
+and identifier = function Id x -> string x
+
+and type_variable_identifier = function TVId x -> string ("'" ^ x)
+
+and type_constructor_identifier = function TCId x -> string x
+
+and label = function LId l -> string l
+
+let save ?(ocaml = false) filename ast =
+  let cout = open_out filename in
+  ToChannel.pretty 0.8 100 cout (program ocaml ast);
+  output_string cout "\n";
+  close_out cout
+
+let string_of what x =
+  let b = Buffer.create 13 in
+  ToBuffer.pretty 0.8 100 b (what x);
+  Buffer.contents b
+
+let trace_pass basename f ext ast =
+  let xast = f basename ast in
+  if !Options.trace then save (basename ^ "." ^ ext) xast;
+  xast

--- a/src/lang/programManipulation.ml
+++ b/src/lang/programManipulation.ml
@@ -1,0 +1,170 @@
+open Position
+open AST
+
+let arrow_type_constructor = TCId "->"
+
+let monoscheme ty = TypeScheme ([], ty)
+
+let arrow pos ity oty =
+  TyApp (with_pos pos arrow_type_constructor, [ ity; oty ])
+
+let product_type_constructor = TCId "*"
+
+let product pos ty1 ty2 =
+  TyApp (with_pos pos product_type_constructor, [ ty1; ty2 ])
+
+exception NoProduct
+
+let unproduct = function
+  | TyApp ({ value = TCId "*" }, tys) -> tys
+  | _ -> raise NoProduct
+
+let rec productn pos = function
+  | [] -> assert false
+  | [x] -> x
+  | x :: xs -> with_pos pos (product pos x (productn pos xs))
+
+module TVSet = Set.Make (struct
+                   type t = type_variable_identifier
+                   let compare = compare
+                 end)
+
+let rec ftv = TVSet.(function
+  | TyVar x ->
+     singleton x
+  | TyApp (_, ts) ->
+     List.fold_left (fun s ty -> union s (ftv ty.value)) empty ts)
+
+module VSet = Set.Make (struct
+                  type t = identifier
+                  let compare = compare
+                end)
+
+let rec pattern_variables = function
+  | PVar (x, _) ->
+     [x]
+  | PTuple ps ->
+     List.fold_left (fun s p -> s @ (pattern_variables p.value)) [] ps
+
+let pattern_variables_set p =
+  VSet.(List.fold_left (fun s x -> add x s) empty (pattern_variables p))
+
+exception UntypedVariableInPattern
+
+let rec pattern_bindings = function
+  | PVar (x, Some s) ->
+     [(x, s)]
+  | PVar (x, None) ->
+     raise UntypedVariableInPattern
+  | PTuple ps ->
+     List.fold_left (fun s p -> s @ pattern_bindings p.value) [] ps
+
+let rec fv = VSet.(function
+  | Var x ->
+     singleton x
+  | Lit _ ->
+     empty
+  | App (t, u) ->
+     union (fv t.value) (fv u.value)
+  | Lam (p, t) ->
+     diff (fv t.value) (pattern_variables_set p.value)
+  | Let (vd, t) ->
+     let (bvs, fvs) = value_definition_fv vd in
+     union fvs (diff (fv t.value) bvs)
+  | Record fs ->
+     List.fold_left (fun s (_, t) -> union s (fv t.value)) empty fs
+  | Tuple ts ->
+     List.fold_left (fun s t -> union s (fv t.value)) empty ts
+  | Proj (t, _) ->
+     fv t.value
+)
+and value_definition_fv = VSet.(function
+  | SimpleValue (p, t, _) ->
+     (pattern_variables_set p.value, fv t.value)
+)
+
+let rec mk_let ds t =
+  match ds with
+  | [] -> t
+  | d :: ds -> with_pos t.position (Let (d, mk_let ds t))
+
+let map fterm p =
+  let rec program p =
+    List.map toplevel_definition p
+  and toplevel_definition = function
+    | ToplevelValue vd ->
+       ToplevelValue (value_definition vd)
+    | td ->
+       td
+  and value_definition = function
+    | SimpleValue (p, t, attributes) ->
+       SimpleValue (p, term' t, attributes)
+  and term' t =
+    with_pos t.position (fterm term t.value)
+  and term = function
+    | Let (d, t) ->
+       Let (value_definition d, term' t)
+    | Lam (p, t) ->
+       Lam (p, term' t)
+    | Tuple ts ->
+       Tuple (List.map term' ts)
+    | Record fs ->
+       Record (List.map (fun (l, t) -> (l, term' t)) fs)
+    | App (t, u) ->
+       App (term' t, term' u)
+    | Proj (t, l) ->
+       Proj (term' t, l)
+    | (Var _ | Lit _) as u ->
+       u
+  in
+  program p
+
+let contextual_map fterm empty bind p =
+  let bind_pattern env p =
+    List.fold_left (fun env x -> bind x env) env (located pattern_variables p)
+  in
+  let rec program p =
+    ExtStd.List.fold_map toplevel_definition empty p
+  and toplevel_definition env = function
+    | ToplevelValue vd ->
+       bind_value_definition env vd, ToplevelValue (value_definition env vd)
+    | td ->
+       env, td
+  and value_definition env = function
+    | SimpleValue (p, t, attributes) ->
+       SimpleValue (p, term' env t, attributes)
+  and term' env t =
+    with_pos t.position (fterm term env t.value)
+  and term env = function
+    | Let (d, t) ->
+       Let (value_definition env d, term' env t)
+    | Lam (p, t) ->
+       let env = bind_pattern env p in
+       Lam (p, term' env t)
+    | Tuple ts ->
+       Tuple (List.map (term' env) ts)
+    | Record fs ->
+       Record (List.map (fun (l, t) -> (l, term' env t)) fs)
+    | App (t, u) ->
+       App (term' env t, term' env u)
+    | Proj (t, l) ->
+       Proj (term' env t, l)
+    | (Var _ | Lit _) as u ->
+       u
+  and bind_value_definition env = function
+    | SimpleValue (p, t, attributes) ->
+       bind_pattern env p
+  in
+  program p
+
+exception UnboundValue of identifier
+
+let rec lookup_definition env f =
+  match env with
+  | [] ->
+     raise (UnboundValue f)
+  | (SimpleValue (p, _, _) as d) :: env ->
+     if VSet.mem f (pattern_variables_set p.value) then
+       d
+     else
+       lookup_definition env f

--- a/src/lang/utilities.ml
+++ b/src/lang/utilities.ml
@@ -1,0 +1,21 @@
+(** Utilities *)
+
+(** [in_order x] incrementally builds a map from [int] to small
+    [int]s. The map depends on the order in which the integers
+    of the domain are observed. *)
+let in_order =
+  let h = Hashtbl.create 13 in
+  let c = ref (-1) in
+  fun (x : int) ->
+  try
+    Hashtbl.find h x
+  with Not_found ->
+    incr c;
+    Hashtbl.add h x !c;
+    !c
+
+(** [fresh_name_generator constructor] returns a fresh name generator
+    for identifier build from [constructor] applied to a string. *)
+let fresh_name_generator constructor =
+  let c = ref 0 in
+  fun p -> incr c; constructor (Printf.sprintf "%s_%d" p !c)


### PR DESCRIPTION
This is a very basic implementation of MiniML, still to be refined. It currently includes a parser, a pretty-printer and a type-checker, available from a small API defined by the `Lang` module.

Still to do:

- [ ] Extend with algebraic data types and pattern-matching
- [ ] Adapt the language for VIT usage
- [ ] Implement a basic module system
- [ ] Move to dune build system
- [ ] Implement an interpreter